### PR TITLE
added out when no username in message

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -139,7 +139,7 @@ class CameraSkill(NeonSkill):
             LOG.info("In picture")
             LOG.debug(message.data)
             today = datetime.datetime.today()
-            user = get_message_user(message)
+            user = get_message_user(message) or os.environ.get('USER', os.environ.get('USERNAME'))
             pic_path = os.path.join(self.pic_path, user)
             if not os.path.exists(pic_path):
                 LOG.debug(f"Creating pictures path: {pic_path}")


### PR DESCRIPTION
# Description
Fixes an error when no `username` is in the message

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->